### PR TITLE
fix: nil pointer dereference in deployment handler when namespace is empty

### DIFF
--- a/internal/handler/deployment/handler.go
+++ b/internal/handler/deployment/handler.go
@@ -34,11 +34,11 @@ func (h *Handler) Filter(destination *v1alpha1.DestinationToWatch, event events.
 	}
 	logger := log.FromContext(h.ctx)
 	var deployments appsv1.DeploymentList
-	var opt client.ListOption
+	var opts []client.ListOption
 	if event.Namespace != "" {
-		opt = client.InNamespace(event.Namespace)
+		opts = append(opts, client.InNamespace(event.Namespace))
 	}
-	if err := h.client.List(h.ctx, &deployments, opt); err != nil {
+	if err := h.client.List(h.ctx, &deployments, opts...); err != nil {
 		return nil, fmt.Errorf("failed to list Deployments:%w", err)
 	}
 	for key, deployment := range deployments.Items {


### PR DESCRIPTION
## Summary

Fixes a panic (nil pointer dereference) in the Deployment handler's `Filter` function when processing events with an empty `Namespace` field — such as events originating from **AWS SQS** notification sources.

## Problem

When a `Config` resource includes an `AwsSqs` notification source alongside a `Deployment` destination, SQS-originated events always have an empty `Namespace` field (since SQS events are not namespace-scoped). The Deployment handler's `Filter` function in `internal/handler/deployment/handler.go` declared a single `client.ListOption` variable and only assigned it when `event.Namespace != ""`:

```go
var opt client.ListOption
if event.Namespace != "" {
    opt = client.InNamespace(event.Namespace)
}
if err := h.client.List(h.ctx, &deployments, opt); err != nil {
```

When the namespace was empty, `opt` remained its zero value (`nil`). Passing a `nil` `client.ListOption` into `client.List` causes `ApplyOptions` to dereference a nil interface, resulting in:

```
panic: runtime error: invalid memory address or nil pointer dereference
```

## Fix

Changed the single `client.ListOption` to a `[]client.ListOption` slice. When the namespace is present, the slice gets one element appended; when it's empty, the slice stays empty. Spreading with `opts...` passes zero variadic arguments, which `client.List` handles correctly — listing deployments across all namespaces:

```go
var opts []client.ListOption
if event.Namespace != "" {
    opts = append(opts, client.InNamespace(event.Namespace))
}
if err := h.client.List(h.ctx, &deployments, opts...); err != nil {
```

This is a one-line behavioral change (3 lines diff) with no impact on the existing KubernetesSecret flow, which always provides a namespace.

Fixes #281