### PR TITLE
deployment/handler: pass variadic ListOption to avoid nil panic

### DIFF
--- a/internal/handler/deployment/handler.go
+++ b/internal/handler/deployment/handler.go
@@ -34,11 +34,11 @@ func (h *Handler) Filter(destination *v1alpha1.DestinationToWatch, event events.
 	}
 	logger := log.FromContext(h.ctx)
 	var deployments appsv1.DeploymentList
-	var opt client.ListOption
+	var opts []client.ListOption
 	if event.Namespace != "" {
-		opt = client.InNamespace(event.Namespace)
+		opts = append(opts, client.InNamespace(event.Namespace))
 	}
-	if err := h.client.List(h.ctx, &deployments, opt); err != nil {
+	if err := h.client.List(h.ctx, &deployments, opts...); err != nil {
 		return nil, fmt.Errorf("failed to list Deployments:%w", err)
 	}
 	for key, deployment := range deployments.Items {


### PR DESCRIPTION
Closes #281. `Filter` declares `var opt client.ListOption` and only assigns when `event.Namespace != ""`. SQS events have an empty Namespace, so `client.List` is called with a nil ListOption and panics. Switch to `opts ...client.ListOption` and pass variadic.